### PR TITLE
Fix logging when level is set on the logger, but no level is set on transports

### DIFF
--- a/lib/winston/transports/transport.js
+++ b/lib/winston/transports/transport.js
@@ -19,7 +19,10 @@ var Transport = exports.Transport = function (options) {
   events.EventEmitter.call(this);
 
   options               = options        || {};
-  this.level            = options.level  || 'info';
+  // Do not set a default level
+  // When this.level is falsey, logger.js uses a logger configured level
+  // (instead of the transport level)
+  this.level            = options.level;
   this.silent           = options.silent || false;
   this.raw              = options.raw    || false;
   this.name             = options.name   || this.name;


### PR DESCRIPTION
Example code:
    var winston = require('winston');
    var logger = new winston.Logger({
      level: 'warn',
      transports: [new winston.transports.Console()]
    });
    logger.info('should not see this');
    logger.warn('should see this');

Expected output:
    should see this

Actual output:
    should not see this
    should see this

Reason: transport.js sets a default level of 'Info' when no level option is set on a transport.  logger.js always uses the transport level (when set) instead of using the level set on the logger.  Since a level is always set on every transport, the logger's level is never used.

I changed transport.js so that it does not set a default value for this.level.  This fixes the issue.
